### PR TITLE
Fix broken import topology feature

### DIFF
--- a/src/main/webapp/static/js/docOrganizer.js
+++ b/src/main/webapp/static/js/docOrganizer.js
@@ -344,7 +344,7 @@ function importNewDoc(files) {
     //var file_data = $("#avatar").prop("files")[0];
     $.ajax({
                 type: 'post',
-                url: "doc/trees",
+                url: BASE_URL + "doc/trees",
                 dataType: "json",
                 contentType: "application/json; charset=UTF-8",
                 cache: false,


### PR DESCRIPTION
Discussed with @martingrambow yesterday: 
Topology import feature was broken because the XHR request missed a URL prefix that was introduced earlier...